### PR TITLE
【修正】Flashメッセージの表示

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -3,5 +3,4 @@
 //= link_tree ../../javascript .js
 //= link_tree ../../../vendor/javascript .js
 //= require jquery
-//= require jquery_ujs
 //= require_tree .

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -15,3 +15,8 @@
   color: #930403;
   border: solid 1px #930403;
 }
+
+/* JavaScriptで非表示にする場合（仮） */
+/* .hide{
+  display: none;
+} */

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -5,5 +5,5 @@ import "controllers";
 
 $(function() {
   $('.flash-message').fadeOut(4000);
-  console.log($('.flash-message'));
+  window.location.reload();
 });

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,9 +1,22 @@
-import $ from 'jquery';
-import "jquery-ujs";
-import "@hotwired/turbo-rails";
-import "controllers";
+// import $ from 'jquery';
+// import "@hotwired/turbo-rails";
+// import "controllers";
 
-$(function() {
-  $('.flash-message').fadeOut(4000);
-  window.location.reload();
-});
+// turboでflashメッセージの非表示を行えるため、コメントアウト
+// $(function() {
+//   $('.flash-message').fadeOut(4000);
+// });
+
+// JavaScriptで非表示にする場合（仮）
+// document.addEventListener("turbo:load", function() {
+//   const flashMessage = document.getElementsByClassName("flash-message");
+//   console.log(flashMessage);
+
+//   if(flashMessage){
+//     setTimeout(function() {
+//       flashMessage.classList.add("hide");
+//       // もしくは
+//       // flashMessage.style.display = "none";
+//     }, 4000);
+//   }
+// });

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,19 +8,19 @@
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
-    <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
 
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
   </head>
 
   <body>
-     <div>
-      <% flash.each do |message_type, message| %>
-        <div class="flash-message <%= message_type %>"><%= message %></div>
-      <% end %>
-     </div>
-     <div id="nav">
+    <% flash.each do |message_type, message| %>
+      <div class="flash-message <%= message_type %>">
+        <%= message %>
+      </div>
+    <% end %>
+    <div id="nav">
       <% if logged_in? %>
-        <%= link_to "ログアウト", logout_path, data: { turbo_method: :delete } %>
+        <%= link_to "ログアウト", logout_path, data: { method: :delete, turbo: false } %>
       <% else %>
         <%= link_to "新規登録", new_user_path %> |
         <%= link_to "ログイン", login_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   get 'login' => 'sessions#new', as: :login
   post 'login' => "sessions#create"
-  delete 'logout' => 'sessions#destroy', as: :logout
+  get 'logout' => 'sessions#destroy', as: :logout
 
   root to: "samples#index"
 


### PR DESCRIPTION
## チケットへのリンク
- なし

## 経緯
- 以前に認証機能のついでにFlashメッセージを実装したが、ログアウト後のメッセージが消えずに残っていることが判明したため。

## やったこと
- Flashメッセージの表示（バリデーション、ログイン・ログアウト時）
- Flashメッセージの非表示
- ルーティング修正（ログアウト）

## やらないこと
- jqueryもしくはjavascriptの使用（Turboでページの再読み込みをすることで、メッセージが消えるようになっているため）

## できるようになること（ユーザ目線）
- エラー発生時とログイン・ログアウト時にFlashメッセージで確認できる

## できなくなること（ユーザ目線）
- なし

## 動作確認
1. http://localhost:3000/login にアクセス
2. ログイン→ログアウトする
3. Flashメッセージが表示されて数秒後に消える（非表示になる）こと


https://github.com/kyohei-p/Minimum-App/assets/107188352/7cb27d7c-50ae-41b1-8237-5c27f5ba0e5a


## レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
- -` <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>`でTurboフレームワークによってページ遷移時に再読み込みを行う。

-（公式） [Hotwire を使用した Flash メッセージ](https://www.hotrails.dev/turbo-rails/flash-messages-hotwire)